### PR TITLE
Delay timer to 5 minutes

### DIFF
--- a/src/qt/dashboardwidget.cpp
+++ b/src/qt/dashboardwidget.cpp
@@ -148,7 +148,7 @@ DashboardWidget::DashboardWidget(ALQOGUI* parent) :
 	//Timer is not set,lets create one.
 	timer = new QTimer(this);
 	connect(timer, SIGNAL(timeout()), this, SLOT(SetExchangeInfoTextLabels()));
-	timer->start(60000);
+	timer->start(300000);
 	timerid = timer->timerId();
 
 }


### PR DESCRIPTION
Due to delays in wallet creation, we will now retrieve exchange data and calculate wallet value every 5 minute interval.  